### PR TITLE
Added delete cascade for groups and events

### DIFF
--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -150,13 +150,7 @@ class EventController extends Controller
         // fetch event from database
         $event = Event::findOrFail($id);
 
-        // remove foreign key constraints: items, messages and replies for this event
-        $event->items()->delete();
-        $event->messages()->delete();
-        $event->replies()->detach();
-
-
-        // delete event from database
+        // delete event from database - this will trigger all dependencies to be removed as well
         $event->delete();
 
         // redirect to home screen and show alert message

--- a/app/Observers/EventObserver.php
+++ b/app/Observers/EventObserver.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Observers;
+
+use App\Event;
+
+class EventObserver
+{
+    // This function is triggered when an event has to be deleted.
+    // It will remove all foreign key constraints, i.e. all items, messages and replies associated with this event
+    public function deleting(Event $event) {
+
+        $event->items()->delete();
+        $event->messages()->delete();
+        $event->replies()->detach();
+    }
+}

--- a/app/Observers/GroupObserver.php
+++ b/app/Observers/GroupObserver.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Observers;
+
+use App\Group;
+
+class GroupObserver
+{
+    // This function is triggered when a group has to be deleted.
+    // It will remove all events associated with this group as well as subscriber / membership information
+    public function deleting(Group $group) {
+
+        // remove all memberships and subscriptions
+        $group->members()->detach();
+        $group->subscribers()->detach();
+
+        // call delete method for each event individually to trigger the corresponding cleanup (delete items, messages & replies)
+        $group->events->each(function($event) {
+            $event->delete();
+        });
+
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,10 @@
 
 namespace App\Providers;
 
+use App\Event;
+use App\Group;
+use App\Observers\EventObserver;
+use App\Observers\GroupObserver;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -13,7 +17,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-
+        Event::observe(EventObserver::class);
+        Group::observe(GroupObserver::class);
     }
 
     /**


### PR DESCRIPTION
Deleting a group or event will trigger the removal of corresponding data (items, replies, etc.)